### PR TITLE
Fix authorization error

### DIFF
--- a/components/api-helpers/APIHelpers.ts
+++ b/components/api-helpers/APIHelpers.ts
@@ -39,15 +39,25 @@ export async function getUserContext(req: Request | IncomingMessage) {
  * Determines whether the user has one or more of the authorized roles to perform a given action
  */
 export async function isUserAuthorized(req: NextApiRequest | NextRequest, res: NextApiResponse, authorizedRoles: string[], orgRef?: string) {
-    const user = await getUserContext(req);
+    
+    try {
+        const user = await getUserContext(req);
 
-    const relevantRoles = orgRef == undefined ? user['roles'] : user['organizations'][orgRef]['roles'];
+        const relevantRoles = orgRef == undefined ? user['roles'] : user['organizations'][orgRef]['roles'];
 
-    const isUserAuthorized = authorizedRoles.some(role => (relevantRoles['roles'] as string[]).indexOf(role) >= 0);
+        const isUserAuthorized = authorizedRoles.some(role => (relevantRoles['roles'] as string[]).indexOf(role) >= 0);
 
-    if (!isUserAuthorized) {
-        res.status(403).json({ result: "User does not have the appropriate permissions."});
+        if (!isUserAuthorized) {
+            res.status(403).json({ result: "User does not have the appropriate permissions."});
+        }
+
+        return isUserAuthorized;
+    } catch (e) {
+        if (process.env.DEBUG === "true") {
+            console.log("Error when attempting authorize user:");
+            console.log(e);
+        }
     }
 
-    return isUserAuthorized;
+    return false;
 }

--- a/pages/api/auth/llt.ts
+++ b/pages/api/auth/llt.ts
@@ -13,14 +13,15 @@ export default async function generateLongLivedToken(req: NextApiRequest, res: N
 	 * Only master administrators should be able to issue service accounts, 
 	 * as such service accounts often have wide-ranging access.
 	 */
-	if (isUserAuthorized(req, res, [UserRole.MASTER_ADMIN])) {
+	if (await isUserAuthorized(req, res, [UserRole.MASTER_ADMIN])) {
 		
 		// By default, long lived tokens should expire after 1 year 
 		const expiration = req.body.expiration ? req.body.expiration : '365d';
 
 		// The roles that the service account should be able to assume
 		const serviceAccount = {
-			roles: req.body.roles
+			roles: req.body.roles,
+			organizations: req.body.organizations
 		};
 
 		const token = await new SignJWT(serviceAccount)
@@ -31,5 +32,7 @@ export default async function generateLongLivedToken(req: NextApiRequest, res: N
 			.sign(new TextEncoder().encode(process.env.JWT_SS));
 
 		res.status(200).json({ result: "Long-lived token created", jwt: token });
+	} else {
+		res.status(403).json({ result: "User not authorized." });
 	}
 }

--- a/pages/api/auth/totp/validate.ts
+++ b/pages/api/auth/totp/validate.ts
@@ -32,7 +32,10 @@ interface EmailRequestBody {
 
 			const roles = await DBConnection.getUserRoles(person.id);
 			const wholePerson = {...personn, ...roles};
-			if (process.env.DEBUG === "true") { console.log(wholePerson); }
+			if (process.env.DEBUG === "true") {
+				console.log("User OTP successfully validated.");
+				console.log(wholePerson);
+			}
 			
 			const token = await new SignJWT(wholePerson)
 				.setProtectedHeader({ alg: 'HS256' })

--- a/pages/api/location/geocode.ts
+++ b/pages/api/location/geocode.ts
@@ -6,7 +6,7 @@ import { isUserAuthorized } from '@/components/api-helpers';
  * Fetches location details using the Google API
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-	if (isUserAuthorized(req, res, ['master-admin'])) {
+	if (await isUserAuthorized(req, res, ['master-admin'])) {
 		const location = req.body.location;
 		const locationResponse = await findLocation(location);
 		res.status(200).json(locationResponse);


### PR DESCRIPTION
Fixes an issue where a user was successfully authorized to generate a long-lived token even when the user's JWT failed validation