### PR TITLE
Fix issue where seeding script was not picking up environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "@vercel/node": "^2.5.14",
+        "dotenv": "^16.0.2",
         "eslint": "8.22.0",
         "eslint-config-next": "12.2.5",
         "eslint-plugin-jsdoc": "^39.3.6",
@@ -5525,6 +5526,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -16535,6 +16545,12 @@
           "dev": true
         }
       }
+    },
+    "dotenv": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "dev": true
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "@vercel/node": "^2.5.14",
+    "dotenv": "^16.0.2",
     "eslint": "8.22.0",
     "eslint-config-next": "12.2.5",
     "eslint-plugin-jsdoc": "^39.3.6",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env ts-node
 
 import { PrismaClient } from '@prisma/client'
+import * as dotenv from 'dotenv';
+
 const prisma = new PrismaClient()
+dotenv.config({ path: '.env.local' });
 
 async function main() {
     


### PR DESCRIPTION
Adds dotenv so that typescript scripts (like prisma/seed.ts) can successfully read environment variables